### PR TITLE
SDS-241 - fix failing definitions update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
 
 RUN pip install -U setuptools certifi
 
-RUN pip install -vv cvdupdate==1.1.1
+RUN pip install -vv cvdupdate==1.2.0
 
 COPY start.sh lighttpdhost.conf lighttpdmirror.conf test.sh ./
 COPY freshclam.conf /etc/clamav/freshclam.conf


### PR DESCRIPTION
## The issue
The automatic virus definitions update that runs every 10 minutes was failing with error message `ModuleNotFoundError: No module named 'pkg_resources'` (see comments below ticket https://dsdmoj.atlassian.net/browse/SDS-241 for more details)

This is because our Dockerfile was specifying installation of `cvdupdate` v1.1.1 which has a dependency on `pkg_resources` but `pkg_resources` was removed from Python's `setuptools` package in February 2026.

## The fix
Use a more recent version of `cvdupdate` that does not depend on `pkg_resources` . This means using v1.1.3 or later. In local run I tried v1.1.3 which worked OK but gave a warning that recommended upgrading to v1.2.0, so I tried v1.2.0 locally as well and found it worked without any warnings or errors.

## Testing
We don't have any dev or test environments from clamav-mirror. I ran the clamav-mirror Docker container locally based on the new Docker image with `cvdupdate` v1.2.0.

It ran without reporting any errors.

```
2026-04-22 12:34:12 PM - DEBUG:  daily.cvd version advertised by DNS: 27979
2026-04-22 12:34:12 PM - DEBUG:  Downloading CDIFFs first...
2026-04-22 12:34:12 PM - DEBUG:  Checking for daily-27979.cdiff
2026-04-22 12:34:12 PM - DEBUG:  Starting new HTTPS connection (1): database.clamav.net:443
2026-04-22 12:34:12 PM - DEBUG:  [https://database.clamav.net:443](https://database.clamav.net/) "GET /daily-27979.cdiff HTTP/1.1" 200 1133
2026-04-22 12:34:12 PM - INFO:  Downloaded daily-27979.cdiff
2026-04-22 12:34:12 PM - DEBUG:  Starting new HTTPS connection (1): database.clamav.net:443
2026-04-22 12:34:12 PM - DEBUG:  [https://database.clamav.net:443](https://database.clamav.net/) "GET /daily-27979.cdiff.sign HTTP/1.1" 200 9078
2026-04-22 12:34:12 PM - INFO:  Downloaded daily-27979.cdiff.sign. Version: 27979
2026-04-22 12:34:12 PM - DEBUG:  Starting new HTTPS connection (1): database.clamav.net:443
2026-04-22 12:34:13 PM - DEBUG:  [https://database.clamav.net:443](https://database.clamav.net/) "GET /daily.cvd?version=27979 HTTP/1.1" 200 23405738
2026-04-22 12:34:21 PM - INFO:  Downloaded daily.cvd. Version: 27979
2026-04-22 12:34:21 PM - DEBUG:  Starting new HTTPS connection (1): database.clamav.net:443
2026-04-22 12:34:22 PM - DEBUG:  [https://database.clamav.net:443](https://database.clamav.net/) "GET /daily-27979.cvd.sign HTTP/1.1" 200 9078
2026-04-22 12:34:22 PM - INFO:  Downloaded daily-27979.cvd.sign. Version: 27979
2026-04-22 12:34:22 PM - DEBUG:  Checking bytecode.cvd for update from https://database.clamav.net/bytecode.cvd
2026-04-22 12:34:22 PM - DEBUG:  Checking bytecode.cvd version via DNS TXT advertisement.
2026-04-22 12:34:22 PM - DEBUG:  bytecode.cvd version advertised by DNS: 339
2026-04-22 12:34:22 PM - DEBUG:  Downloading CDIFFs first...
2026-04-22 12:34:22 PM - DEBUG:  Checking for bytecode-339.cdiff
2026-04-22 12:34:22 PM - DEBUG:  Starting new HTTPS connection (1): database.clamav.net:443
2026-04-22 12:34:22 PM - DEBUG:  [https://database.clamav.net:443](https://database.clamav.net/) "GET /bytecode-339.cdiff HTTP/1.1" 200 806
2026-04-22 12:34:22 PM - INFO:  Downloaded bytecode-339.cdiff
2026-04-22 12:34:22 PM - DEBUG:  Starting new HTTPS connection (1): database.clamav.net:443
2026-04-22 12:34:22 PM - DEBUG:  [https://database.clamav.net:443](https://database.clamav.net/) "GET /bytecode-339.cdiff.sign HTTP/1.1" 200 9078
2026-04-22 12:34:22 PM - INFO:  Downloaded bytecode-339.cdiff.sign. Version: 339
2026-04-22 12:34:22 PM - DEBUG:  Starting new HTTPS connection (1): database.clamav.net:443
2026-04-22 12:34:22 PM - DEBUG:  [https://database.clamav.net:443](https://database.clamav.net/) "GET /bytecode.cvd?version=339 HTTP/1.1" 200 281702
2026-04-22 12:34:23 PM - INFO:  Downloaded bytecode.cvd. Version: 339
2026-04-22 12:34:23 PM - DEBUG:  Starting new HTTPS connection (1): database.clamav.net:443
2026-04-22 12:34:23 PM - DEBUG:  [https://database.clamav.net:443](https://database.clamav.net/) "GET /bytecode-339.cvd.sign HTTP/1.1" 200 9078
2026-04-22 12:34:23 PM - INFO:  Downloaded bytecode-339.cvd.sign. Version: 339
Saved: /home/clam/.cvdupdate/config.json
```
Also routine 10 minute updates showed as working (portion of log)
```
2026-04-22 12:50:00 PM - DEBUG:  Checking daily.cvd for update from https://database.clamav.net/daily.cvd
2026-04-22 12:50:00 PM - DEBUG:  Checking daily.cvd version via DNS TXT advertisement.
2026-04-22 12:50:00 PM - DEBUG:  daily.cvd version advertised by DNS: 27979
2026-04-22 12:50:00 PM - INFO:  daily.cvd is up-to-date. Version: 27979
2026-04-22 12:50:00 PM - DEBUG:  We already have daily-27979.cvd.sign. Skipping...
2026-04-22 12:50:00 PM - DEBUG:  Checking bytecode.cvd for update from https://database.clamav.net/bytecode.cvd
2026-04-22 12:50:00 PM - DEBUG:  Checking bytecode.cvd version via DNS TXT advertisement.
2026-04-22 12:50:00 PM - DEBUG:  bytecode.cvd version advertised by DNS: 339
2026-04-22 12:50:00 PM - INFO:  bytecode.cvd is up-to-date. Version: 339
2026-04-22 12:50:00 PM - DEBUG:  We already have bytecode-339.cvd.sign. Skipping...
Saved: /home/clam/.cvdupdate/config.json
```
Later (portion of log)
```
2026-04-22 01:00:00 PM - DEBUG:  Checking daily.cvd for update from https://database.clamav.net/daily.cvd
2026-04-22 01:00:00 PM - DEBUG:  Checking daily.cvd version via DNS TXT advertisement.
2026-04-22 01:00:00 PM - DEBUG:  daily.cvd version advertised by DNS: 27979
2026-04-22 01:00:00 PM - INFO:  daily.cvd is up-to-date. Version: 27979
2026-04-22 01:00:00 PM - DEBUG:  We already have daily-27979.cvd.sign. Skipping...
2026-04-22 01:00:00 PM - DEBUG:  Checking bytecode.cvd for update from https://database.clamav.net/bytecode.cvd
2026-04-22 01:00:00 PM - DEBUG:  Checking bytecode.cvd version via DNS TXT advertisement.
2026-04-22 01:00:00 PM - DEBUG:  bytecode.cvd version advertised by DNS: 339
2026-04-22 01:00:00 PM - INFO:  bytecode.cvd is up-to-date. Version: 339
2026-04-22 01:00:00 PM - DEBUG:  We already have bytecode-339.cvd.sign. Skipping...
Saved: /home/clam/.cvdupdate/config.json

```
